### PR TITLE
Include example on how to use this with Mocha/Se

### DIFF
--- a/mocha-se-example.js
+++ b/mocha-se-example.js
@@ -1,0 +1,33 @@
+import assert from 'assert';
+import test from 'selenium-webdriver/testing';
+var browserstack = require('browserstack-local');
+var local = new browserstack.Local();
+let localOptions = {
+  'key': 'BrowserStack Access Key Goes Here!'
+};
+
+test.before(function(done) {
+  this.timeout(30000);
+  console.log('Starting BrowserStack-Local...');
+  local.start(localOptions, ()=>{
+    console.log("Started BrowserStack-Local.");
+    // ...Code to start WebDriver goes here...
+    done();
+  });
+});
+
+test.after(function() {
+  this.timeout(30000);
+  // ...Code to stop WebDriver goes here...
+  console.log('Stopping BrowserStack-Local...');
+  local.stop(()=>{
+    console.log("Stopped BrowserStack-Local");
+  });
+});
+
+test.describe('Example Test Suite 1', function() {
+  this.timeout(30000);  
+  test.it('Example Test Case 1', function() {
+    // ...Test Case Code goes here...
+  });
+});


### PR DESCRIPTION
Included an example on how to do this with Mocha/Se WebDriver JS. This can save someone much time, as it showcases the need for a done() callback in the test.before hook. This is necessary to work with the async nature of this browserstack-local module, otherwise a race condition is present between the local binary being run and the webdriver attempting to connect to it.