### PR TITLE
Ensure calling .stop does not error if callback is not passed in

### DIFF
--- a/lib/Local.js
+++ b/lib/Local.js
@@ -104,6 +104,8 @@ function Local(){
   };
 
   this.stop = function (callback) {
+    if(typeof callback === 'undefined')
+      callback = function() {};
     if(!this.pid) return callback();
     this.opcode = 'stop';
     this.tunnel = childProcess.execFile(this.binaryPath, this.getBinaryArgs(), function(error){

--- a/test/local.js
+++ b/test/local.js
@@ -211,6 +211,7 @@ describe('Local', function () {
   })
 
   it('does not error if no callback in stop', function (done) {
+    this.timeout(60000);
     bsLocal.start({ 'key': process.env.BROWSERSTACK_ACCESS_KEY }, function(){
       bsLocal.stop();
       done();

--- a/test/local.js
+++ b/test/local.js
@@ -182,9 +182,9 @@ describe('Local', function () {
   });
 
   it('should set proxy', function (done) {
-    bsLocal.start({ 
-      'key': process.env.BROWSERSTACK_ACCESS_KEY, 
-      onlyCommand: true, 
+    bsLocal.start({
+      'key': process.env.BROWSERSTACK_ACCESS_KEY,
+      onlyCommand: true,
       'proxyHost': 'localhost',
       'proxyPort': 8080,
       'proxyUser': 'user',
@@ -208,7 +208,14 @@ describe('Local', function () {
       expect(bsLocal.getBinaryArgs().indexOf('localhost,8000,0')).to.not.equal(-1);
       done();
     });
-  });
+  })
+
+  it('does not error if no callback in stop', function (done) {
+    bsLocal.start({ 'key': process.env.BROWSERSTACK_ACCESS_KEY }, function(){
+      bsLocal.stop();
+      done();
+    });
+  })
 
   afterEach(function (done) {
     this.timeout(60000);


### PR DESCRIPTION
Before this PR calling `.stop()` without a callback would error