### PR TITLE
added default callbacks if not specified to start / stop

### DIFF
--- a/lib/Local.js
+++ b/lib/Local.js
@@ -18,6 +18,9 @@ function Local(){
   this.doneRegex = /Press Ctrl-C to exit/i;
 
   this.start = function(options, callback){
+    if(typeof callback !== 'function')
+      callback = function(){};
+
     this.userArgs = [];
     var that = this;
     this.addArgs(options);
@@ -104,6 +107,9 @@ function Local(){
   };
 
   this.stop = function (callback) {
+    if(typeof callback !== 'function')
+      callback = function(){};
+
     if(!this.pid) return callback();
     this.opcode = 'stop';
     this.tunnel = childProcess.execFile(this.binaryPath, this.getBinaryArgs(), function(error){


### PR DESCRIPTION
This PR adds a default callback of an empty function to both start/stop. In the examples for start/stop, you end up doing something like:
```javascript
browserstack_local.start(args, function () {
    console.log('browserstack local running');
});

browserstack_local.stop(function () {
    console.log('browserstack local closed');
});
```

This led me to assume that the two callbacks were optional, since they're not used for anything vital in this case. However, when running my tests locally and not specifying a callback, I got an error due to the callback not being specified.

This will make it so that, should a dev decide not to wait for the start / stop (something which a lot of devs might do), they can instead just call `browserstack_local.start(args)` / `browserstack_local.stop()` and continue onwards.