### PR TITLE
update https-proxy-agent to fix vulnerability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: node_js
 node_js:
-  - "4.3"
-  - "4.0"
-  - "0.12"
-  - "0.10"
+  - "6"
+  - "8"
+  - "10"
 
 before_install:
   - true && `base64 --decode <<< ZXhwb3J0IEJST1dTRVJTVEFDS19BQ0NFU1NfS0VZPUh5VmZydXJvb3dYb041eGhLZEs2Cg==`

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "author": "BrowserStack",
   "license": "MIT",
   "dependencies": {
-    "https-proxy-agent": "^1.0.0",
+    "https-proxy-agent": "^2.2.1",
     "is-running": "^2.0.0",
     "sinon": "^1.17.6",
     "temp-fs": "^0.9.9"
@@ -32,9 +32,8 @@
   },
   "bugs": "https://github.com/browserstack/browserstack-local-nodejs/issues",
   "homepage": "https://github.com/browserstack/browserstack-local-nodejs",
-  "repository": { 
-    "type" : "git", 
-    "url" : "https://github.com/browserstack/browserstack-local-nodejs.git"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/browserstack/browserstack-local-nodejs.git"
   }
 }
-


### PR DESCRIPTION
Fixes https://nodesecurity.io/advisories/593

Looked at the changelog and it doesn't appear there is any
breaking change relevant to the library.

https://github.com/TooTallNate/node-https-proxy-agent/blob/master/History.md#200--2017-06-26