### PR TITLE
Fix argument order sent via command line to browserstack local binary.

### DIFF
--- a/lib/Local.js
+++ b/lib/Local.js
@@ -199,12 +199,12 @@ function Local(){
 
   this.getBinaryArgs = function(){
     var args = ['--daemon', this.opcode, '--log-file', this.logfile];
-    if(this.folderFlag)
-      args.push(this.folderFlag);
     if(this.key) {
       args.push('--key');
       args.push(this.key);
     }
+    if(this.folderFlag)
+      args.push(this.folderFlag);
     if(this.folderPath)
       args.push(this.folderPath);
     if(this.forceLocalFlag)


### PR DESCRIPTION
Previously, the folder flag and folder value were split by the key argument.