### PR TITLE
move sinon to a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "https-proxy-agent": "^2.2.1",
     "is-running": "^2.0.0",
     "ps-tree": "=1.1.1",
-    "sinon": "^1.17.6",
     "temp-fs": "^0.9.9"
   },
   "devDependencies": {
@@ -29,7 +28,8 @@
     "mocha": "2.4.5",
     "mocks": "0.0.15",
     "proxy": "^0.2.4",
-    "rimraf": "^2.5.4"
+    "rimraf": "^2.5.4",
+    "sinon": "^1.17.6"
   },
   "bugs": "https://github.com/browserstack/browserstack-local-nodejs/issues",
   "homepage": "https://github.com/browserstack/browserstack-local-nodejs",


### PR DESCRIPTION
The `sinon` used by this package is kind of ancient and it's relying on even more ancient packages (`samsam`) - by moving it to `devDependencies`, consumers won't have to install it or its old dependencies.