### PR TITLE
Upgrade Dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,18 +18,18 @@
   "license": "MIT",
   "dependencies": {
     "https-proxy-agent": "^2.2.1",
-    "is-running": "^2.0.0",
-    "ps-tree": "=1.1.1",
-    "sinon": "^1.17.6",
-    "temp-fs": "^0.9.9"
+    "is-running": "^2.1.0",
+    "ps-tree": "^1.2.0"
   },
   "devDependencies": {
-    "eslint": "1.10.3",
-    "expect.js": "0.3.1",
-    "mocha": "2.4.5",
-    "mocks": "0.0.15",
+    "eslint": "^5.15.3",
+    "expect.js": "^0.3.1",
+    "mocha": "^6.0.2",
+    "mocks": "^0.0.15",
     "proxy": "^0.2.4",
-    "rimraf": "^2.5.4"
+    "rimraf": "^2.6.3",
+    "sinon": "^7.2.7",
+    "temp-fs": "^0.9.9"
   },
   "bugs": "https://github.com/browserstack/browserstack-local-nodejs/issues",
   "homepage": "https://github.com/browserstack/browserstack-local-nodejs",

--- a/test/local.js
+++ b/test/local.js
@@ -182,9 +182,9 @@ describe('Local', function () {
   });
 
   it('should set proxy', function (done) {
-    bsLocal.start({ 
-      'key': process.env.BROWSERSTACK_ACCESS_KEY, 
-      onlyCommand: true, 
+    bsLocal.start({
+      'key': process.env.BROWSERSTACK_ACCESS_KEY,
+      onlyCommand: true,
       'proxyHost': 'localhost',
       'proxyPort': 8080,
       'proxyUser': 'user',
@@ -259,13 +259,13 @@ describe('LocalBinary', function () {
     });
 
     beforeEach(function() {
-      sandBox = sinon.sandbox.create();
+      sandBox = sinon.createSandbox();
     });
 
     it('Tries to download binary if its corrupted', function(done) {
       fs.unlink(defaultBinaryPath, function() {
         var localBinary = new LocalBinary();
-        var downloadStub = sandBox.stub(localBinary, 'download', function() {
+        var downloadStub = sandBox.stub(localBinary, 'download').callsFake(function() {
           downloadStub.callArgWith(2, [ defaultBinaryPath ]);
           expect(downloadStub.args[0][3]).to.be(5);
         });
@@ -285,7 +285,7 @@ describe('LocalBinary', function () {
     it('Tries to download binary if its not present', function(done) {
       fs.unlink(defaultBinaryPath, function() {
         var localBinary = new LocalBinary();
-        var downloadStub = sandBox.stub(localBinary, 'download', function() {
+        var downloadStub = sandBox.stub(localBinary, 'download').callsFake(function() {
           downloadStub.callArgWith(2, [ defaultBinaryPath ]);
           expect(downloadStub.args[0][3]).to.be(5);
         });


### PR DESCRIPTION
- Move testing dependencies to `devDependencies`.
- Upgrade all dependencies to latest versions.
- Removes deprecated warnings.