### PR TITLE
Fix no output error.

### DIFF
--- a/lib/Local.js
+++ b/lib/Local.js
@@ -54,12 +54,14 @@ function Local(){
         }
 
         var data = {};
-        if(stdout)
+        if(!!stdout)
           data = JSON.parse(stdout);
         else if(stderr)
           data = JSON.parse(stderr);
-        else
+        else {
           callback(new LocalError('No output received'));
+          return;
+        }
 
         if(data['state'] != 'connected'){
           callback(new LocalError(data['message']['message']));


### PR DESCRIPTION
To prevent data.message.message`` is accessed on {}`:
1.  callback with 'No output received' `LocalError`, if `stdout` is empty
2. return on error

Fix for issue #96 
