### PR TITLE
Update proxy settings to use dashed in params

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ To use a proxy for local testing -
 * proxyPass: Password for USERNAME, will be ignored if USERNAME is empty or not specified
 
 ```js
-bs_local_args = { 'key': '<browserstack-accesskey>', 'proxyHost': '127.0.0.1', 'proxyPort': '8000', 'proxyUser': 'user', 'proxyPass': 'password' }
+bs_local_args = { 'key': '<browserstack-accesskey>', 'local-proxy-host': '127.0.0.1', 'local-proxy-port': '8000', 'local-proxy-user': 'user', 'local-proxy-pass': 'password' }
 ```
 
 #### Local Proxy
@@ -92,7 +92,7 @@ To use local proxy in local testing -
 * localProxyPass: Password for USERNAME, will be ignored if USERNAME is empty or not specified
 
 ```
-bs_local_args = { 'key': '<browserstack-accesskey>', 'localProxyHost': '127.0.0.1', 'localProxyPort': '8000', 'localProxyUser': 'user', 'localProxyPass': 'password' }
+bs_local_args = { 'key': '<browserstack-accesskey>', 'local-proxy-host': '127.0.0.1', 'local-proxy-port': '8000', 'local-proxy-user': 'user', 'local-proxy-pass': 'password' }
 ```
 
 #### PAC (Proxy Auto-Configuration)


### PR DESCRIPTION
While this was not working:

```js
  const bs_local_args = {
    key: "***",
    localIdentifier: "testing",

    // Never proceeds with the following settings:
    proxyHost: "localhost",
    proxyPort: PORT,

    // If I omit the folder with the proxy settings it returns "LocalError: No output received"
    // f: "/Users/adriaan/folder"
  };
```

This is:

```js
const bs_local_args = {
    key: "***",
    localIdentifier: "testing",
    forceLocal: "true",

    // update here
    'local-proxy-host': "localhost",
    'local-proxy-port': PORT,

    f: "/Users/adriaan/folder"
  };
```

So I updated the docs to reflect this.

Related issue: https://github.com/browserstack/browserstack-local-nodejs/issues/100#issuecomment-591372538