### PR TITLE
[Typescript] Wrong verbose Options type

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To enable verbose logging -
 ```js
 bs_local_args = { 'key': '<browserstack-accesskey>', 'verbose': 'true' }
 ```
-Note - Possible values for 'verbose' modifier are '1', '2', '3' and 'true'
+Note - Possible values for 'verbose' modifier are true, false, '1', '2', '3', 'true' and 'false'
 
 #### Folder Testing
 To test local folder rather internal server, provide path to folder as value of this option -

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,9 @@
 declare module "browserstack-local" {
+  type VerboseLevels = boolean | '1' | '2' | '3'
+
   interface Options {
     key: string;
-    verbose: boolean;
+    verbose: VerboseLevels;
     force: boolean;
     only: string;
     onlyAutomate: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 declare module "browserstack-local" {
-  type VerboseLevels = boolean | '1' | '2' | '3'
+  type VerboseLevels = boolean | 'true' | 'false' | '1' | '2' | '3'
 
   interface Options {
     key: string;


### PR DESCRIPTION
As statued from the [README](https://github.com/browserstack/browserstack-local-nodejs#verbose-logging)
>  Possible values for 'verbose' modifier are '1', '2', '3' and 'true'

The `verbose` Options type is `boolean` which is not handling the other possible values: 'true', 'false', '1', '2', '3'