### PR TITLE
checking key value

### DIFF
--- a/lib/Local.js
+++ b/lib/Local.js
@@ -91,7 +91,8 @@ function Local(){
 
       switch(key){
       case 'key':
-        this.key = value;
+        if(value)
+          this.key = value;
         break;
 
       case 'verbose':


### PR DESCRIPTION
webdriverio has a bug which passes the value as undefined, local lib which already has the value of BROWSERSTACK_ACCESS_KEY through env is replaced by undefined