### PR TITLE
Fixed shell command built from environment values

### DIFF
--- a/lib/Local.js
+++ b/lib/Local.js
@@ -37,7 +37,7 @@ function Local(){
 
     const binaryPath = this.getBinaryPath(null, options['bs-host']);
     that.binaryPath = binaryPath;
-    childProcess.exec('echo "" > ' + that.logfile);
+    fs.writeFileSync(that.logfile, '');
     that.opcode = 'start';
     if(!this.binaryPath){
       return new LocalError('Couldn\'t find binary file');
@@ -86,9 +86,46 @@ function Local(){
 
     this.getBinaryPath(function(binaryPath){
       that.binaryPath = binaryPath;
-      childProcess.exec('echo "" > ' + that.logfile);
+      fs.writeFile(that.logfile, '', function(err) {
+        if (err) {
+          return callback(new LocalError('Failed to create log file: ' + err.message));
+        }
+        that.opcode = 'start';
+        that.tunnel = childProcess.execFile(that.binaryPath, that.getBinaryArgs(), function(error, stdout, stderr){
+          if(error) {
+            const binaryDownloadErrorMessage = `Error while trying to execute binary: ${util.format(error)}`;
+            console.error(binaryDownloadErrorMessage);
+            if(that.retriesLeft > 0) {
+              console.log('Retrying Binary Download. Retries Left', that.retriesLeft);
+              that.retriesLeft -= 1;
+              fs.unlinkSync(that.binaryPath);
+              delete(that.binaryPath);
+              process.env.BINARY_DOWNLOAD_ERROR_MESSAGE = binaryDownloadErrorMessage;
+              process.env.BINARY_DOWNLOAD_FALLBACK_ENABLED = true;
+              that.start(options, callback);
+              return;
+            } else {
+              callback(new LocalError(error.toString()));
+            }
+          }
 
-      that.opcode = 'start';
+          var data = {};
+          if(stdout)
+            data = JSON.parse(stdout);
+          else if(stderr)
+            data = JSON.parse(stderr);
+          else
+            callback(new LocalError('No output received'));
+
+          if(data['state'] != 'connected'){
+            callback(new LocalError(data['message']['message']));
+          } else {
+            that.pid = data['pid'];
+            that.isProcessRunning = true;
+            callback();
+          }
+        });
+      });
       that.tunnel = childProcess.execFile(that.binaryPath, that.getBinaryArgs(), function(error, stdout, stderr){
         if(error) {
           const binaryDownloadErrorMessage = `Error while trying to execute binary: ${util.format(error)}`;


### PR DESCRIPTION
https://github.com/browserstack/browserstack-local-nodejs/blob/440aa806810347033b641a09cc24704f115e7448/lib/Local.js#L40-L40
https://github.com/browserstack/browserstack-local-nodejs/blob/440aa806810347033b641a09cc24704f115e7448/lib/Local.js#L89-L91

Dynamically constructing a shell command with values from the local environment, such as file paths, may inadvertently change the meaning of the shell command. Such changes can occur when an environment value contains characters that the shell interprets in a special way, for instance quotes and spaces. This can result in the shell command misbehaving, or even allowing a malicious user to execute arbitrary commands on the system.



fix this problem, we should avoid constructing shell commands by concatenating potentially unsafe values and passing them to `childProcess.exec`. Instead, we should use Node's built-in file system APIs to perform the intended operation. In this case, the command `'echo "" > logfile'` is intended to truncate or create an empty log file. The equivalent and safer approach is to use `fs.writeFileSync(logfile, '')` (for synchronous code) or `fs.writeFile(logfile, '', callback)` (for asynchronous code). This avoids invoking a shell entirely and is cross-platform.

Specifically, in `lib/Local.js`, replace both instances of `childProcess.exec('echo "" > ' + that.logfile);` (in both `startSync` and `start`) with the appropriate `fs.writeFileSync` or `fs.writeFile` calls. No new imports are needed, as `fs` is already imported.
