### PR TITLE
LOC-6727: validate source URL host before binary download

### DIFF
--- a/lib/fetchDownloadSourceUrl.js
+++ b/lib/fetchDownloadSourceUrl.js
@@ -1,7 +1,7 @@
 const https = require('https'),
   fs = require('fs'),
   HttpsProxyAgent = require('https-proxy-agent'),
-  { isUndefined } = require('./util');
+  { isUndefined, validateSourceUrl } = require('./util');
 
 const authToken = process.argv[2], bsHost = process.argv[3], proxyHost = process.argv[6], proxyPort = process.argv[7], useCaCertificate = process.argv[8], downloadFallback = process.argv[4], downloadErrorMessage = process.argv[5];
 
@@ -45,7 +45,7 @@ const req = https.request(options, res => {
       if(reqBody.error) {
         throw reqBody.error;
       }
-      console.log(reqBody.data.endpoint);
+      console.log(validateSourceUrl(reqBody.data.endpoint));
     } catch (e) {
       console.error(e);
     }

--- a/lib/fetchDownloadSourceUrlAsync.js
+++ b/lib/fetchDownloadSourceUrlAsync.js
@@ -1,7 +1,7 @@
 const https = require('https'),
   fs = require('fs'),
   HttpsProxyAgent = require('https-proxy-agent'),
-  { isUndefined } = require('./util'),
+  { isUndefined, validateSourceUrl } = require('./util'),
   version = require('../package.json').version;
 
 const packageName = 'browserstack-local-nodejs';
@@ -48,7 +48,7 @@ function fetchDownloadSourceUrlAsync(authToken, bsHost, downloadFallback, downlo
         if(reqBody.error) {
           throw reqBody.error;
         }
-        callback(null, reqBody.data.endpoint);
+        callback(null, validateSourceUrl(reqBody.data.endpoint));
       } catch (e) {
         console.error(e);
         callback(e);

--- a/lib/util.js
+++ b/lib/util.js
@@ -5,6 +5,11 @@ module.exports.isUndefined = value => (value === undefined || value === null || 
 const ALLOWED_DOWNLOAD_HOSTS = ['browserstack.com'];
 const ALLOWED_DOWNLOAD_HOST_SUFFIXES = ['.browserstack.com'];
 
+// Each guard below covers a case the final host-equals check does not:
+//   - empty/non-string URL: new url.URL(null) throws TypeError; explicit guard returns a clean message.
+//   - URL constructor catch: convert TypeError on malformed input into our own Error.
+//   - HTTPS check: allowlist matches host only; without this, http://browserstack.com would pass.
+//   - null/empty hostname: URL constructor accepts forms like https:///foo where hostname is empty; give a clear error.
 module.exports.validateSourceUrl = function(sourceUrl) {
   if (!sourceUrl || typeof sourceUrl !== 'string') {
     throw new Error('Refusing binary download: empty source URL');

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,1 +1,30 @@
+const url = require('url');
+
 module.exports.isUndefined = value => (value === undefined || value === null || value === 'undefined');
+
+const ALLOWED_DOWNLOAD_HOSTS = ['browserstack.com'];
+const ALLOWED_DOWNLOAD_HOST_SUFFIXES = ['.browserstack.com'];
+
+module.exports.validateSourceUrl = function(sourceUrl) {
+  if (!sourceUrl || typeof sourceUrl !== 'string') {
+    throw new Error('Refusing binary download: empty source URL');
+  }
+  let parsed;
+  try {
+    parsed = new url.URL(sourceUrl);
+  } catch (e) {
+    throw new Error('Refusing binary download: malformed source URL');
+  }
+  if (parsed.protocol !== 'https:') {
+    throw new Error('Refusing binary download from non-HTTPS source URL');
+  }
+  const host = (parsed.hostname || '').toLowerCase();
+  if (!host) {
+    throw new Error('Refusing binary download: source URL has no host');
+  }
+  if (ALLOWED_DOWNLOAD_HOSTS.indexOf(host) !== -1) return sourceUrl;
+  for (const suffix of ALLOWED_DOWNLOAD_HOST_SUFFIXES) {
+    if (host.endsWith(suffix)) return sourceUrl;
+  }
+  throw new Error("Refusing binary download: host '" + host + "' is not in the allowed host list");
+};


### PR DESCRIPTION
## Summary
Mirror the host allowlist added in [browserstack-local-java#99](https://github.com/browserstack/browserstack-local-java/pull/99) and [browserstack-local-python#62](https://github.com/browserstack/browserstack-local-python/pull/62). The `endpoint` returned by the binary endpoint API is now validated in both `fetchDownloadSourceUrl.js` (sync) and `fetchDownloadSourceUrlAsync.js` paths before being used to download the binary:
- must be HTTPS
- host must be `browserstack.com` or a `*.browserstack.com` subdomain

Validator is shared in `lib/util.js`.

## Test plan
- [ ] Unit test: existing tests still pass
- [ ] Manual: normal binary download still works (endpoint resolves under `*.browserstack.com`)
- [ ] Manual: confirm a synthetic non-allowlisted endpoint throws `Refusing binary download: host '...' is not in the allowed host list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)