### PR TITLE
LOC-6805: allowlist option keys forwarded to the BrowserStackLocal binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ bs_local.start(bs_local_args, function() {
 
 Apart from the key, all other BrowserStack Local modifiers are optional. For the full list of modifiers, refer [BrowserStack Local modifiers](https://www.browserstack.com/local-testing#modifiers). For examples, refer below -
 
+Only documented modifiers are forwarded to the binary. An unrecognised option key, an option the wrapper sets itself (`daemon`, `log-file`), or a value beginning with `-` is refused with an error rather than passed through to the `BrowserStackLocal` argv — otherwise any code that merges untrusted input into the options object could inject arbitrary flags into the binary.
+
 #### Verbose Logging
 To enable verbose logging -
 ```js

--- a/lib/Local.js
+++ b/lib/Local.js
@@ -9,6 +9,60 @@ var childProcess = require('child_process'),
   version = require('../package.json').version,
   treeKill = require('tree-kill');
 
+// Option keys this wrapper is allowed to forward verbatim to the
+// BrowserStackLocal daemon. Mirrors the binary's own CLI definition
+// (COMMAND_CONFIGURATION in browserStackTunnel, extensions/node/config/constants.js)
+// — long names and their aliases — so every documented modifier keeps working
+// while an unrecognised key can no longer reach the daemon argv.
+var PASSTHROUGH_OPTIONS = [
+  'key', 'folder', 'help', 'version', 'force', 'only',
+  'forcelocal', 'force-local',
+  'verbose',
+  'onlyAutomate', 'only-automate',
+  'proxyHost', 'proxy-host',
+  'proxyPort', 'proxy-port',
+  'proxyUser', 'proxy-user',
+  'proxyPass', 'proxy-pass',
+  'localIdentifier', 'local-identifier',
+  'forceproxy', 'force-proxy',
+  'region',
+  'localProxyHost', 'local-proxy-host',
+  'localProxyPort', 'local-proxy-port',
+  'localProxyUser', 'local-proxy-user',
+  'localProxyPass', 'local-proxy-pass',
+  'enableLoggingForAPI', 'enable-logging-for-api',
+  'logFile',
+  'pacFile', 'pac-file',
+  'parallelRuns', 'parallel-runs',
+  'disableProxyDiscovery', 'disable-proxy-discovery',
+  'enableUTCLogging', 'enable-utc-logging',
+  'no-container',
+  'include-hosts', 'exclude-hosts',
+  'bsHost', 'bs-host',
+  'debug-utility', 'debug-url',
+  'customRepeater', 'custom-repeater',
+  'enterprise',
+  'use-system-installed-ca', 'use-ca-certificate',
+  'https-ports',
+  'ntlm-username', 'ntlm-password', 'ntlm-domain', 'ntlm-workstation',
+  'connect-timeout',
+  'public-interface-services',
+  'disableDashboard', 'disable-dashboard',
+  'config-file',
+  'client-protocol',
+  'identifier',
+  'trusted-hosts'
+];
+
+// Flags getBinaryArgs() always puts on the argv itself. Accepting them from
+// the options object too would let a caller append a second, conflicting copy
+// — e.g. '--daemon stop' after our '--daemon start'. ('logFile' has its own
+// supported option; only the raw binary alias is reserved.)
+var RESERVED_OPTIONS = ['daemon', 'log-file', 'source'];
+
+// Keys consumed by this wrapper and never meant for the binary.
+var INTERNAL_OPTIONS = ['onlyCommand'];
+
 function Local(){
   this.sanitizePath = function(rawPath) {
     var doubleQuoteIfRequired = this.windows && !rawPath.match(/"[^"]+"/) ? '"' : '';
@@ -30,7 +84,9 @@ function Local(){
   this.startSync = function(options) {
     this.userArgs = [];
     var that = this;
-    this.addArgs(options);
+    const argsError = this.addArgs(options);
+    if(argsError)
+      return argsError;
 
     if(typeof options['onlyCommand'] !== 'undefined')
       return;
@@ -83,7 +139,9 @@ function Local(){
   this.start = function(options, callback){
     this.userArgs = [];
     var that = this;
-    this.addArgs(options);
+    const argsError = this.addArgs(options);
+    if(argsError)
+      return callback(argsError);
 
     if(typeof options['onlyCommand'] !== 'undefined')
       return callback();
@@ -245,16 +303,44 @@ function Local(){
           this.binaryPath = value;
         break;
 
-      default:
-        if(value.toString().toLowerCase() == 'true'){
-          this.userArgs.push('--' + key);
-        } else {
-          this.userArgs.push('--' + key);
-          this.userArgs.push(value);
-        }
+      default: {
+        var error = this.addUserArg(key, value);
+        if(error)
+          return error;
         break;
       }
+      }
     }
+  };
+
+  // Forwards one caller-supplied option to the daemon argv, or returns a
+  // LocalError describing why it was refused. Only documented modifiers get
+  // through: an unknown key used to be prefixed with '--' and pushed blindly,
+  // which let any caller inject arbitrary flags into the native binary.
+  this.addUserArg = function(key, value){
+    if(INTERNAL_OPTIONS.indexOf(key) !== -1)
+      return;
+
+    if(RESERVED_OPTIONS.indexOf(key) !== -1)
+      return new LocalError('Option \'' + key + '\' is set by browserstack-local itself and cannot be passed in');
+
+    if(PASSTHROUGH_OPTIONS.indexOf(key) === -1)
+      return new LocalError('Unknown option \'' + key + '\'. Only documented BrowserStack Local modifiers are forwarded to the binary, see https://www.browserstack.com/local-testing#modifiers');
+
+    var stringValue = value === undefined || value === null ? '' : value.toString();
+
+    if(stringValue.toLowerCase() == 'true'){
+      this.userArgs.push('--' + key);
+      return;
+    }
+
+    // The binary's argv parser will not consume a value that begins with '-';
+    // it reads it as another flag instead. Refuse rather than smuggle one in.
+    if(stringValue.charAt(0) === '-')
+      return new LocalError('Invalid value for option \'' + key + '\': values starting with \'-\' are not allowed');
+
+    this.userArgs.push('--' + key);
+    this.userArgs.push(value);
   };
 
   this.getBinaryPath = function(callback, bsHost){

--- a/lib/Local.js
+++ b/lib/Local.js
@@ -14,6 +14,12 @@ var childProcess = require('child_process'),
 // (COMMAND_CONFIGURATION in browserStackTunnel, extensions/node/config/constants.js)
 // — long names and their aliases — so every documented modifier keeps working
 // while an unrecognised key can no longer reach the daemon argv.
+//
+// Deliberately a COMPLETE mirror, so it can be diffed against the binary's CLI
+// when that gains a flag. Some entries (key, folder, force, only, forcelocal,
+// verbose, onlyAutomate, proxyHost/Port/User/Pass, localIdentifier, forceproxy,
+// logFile, parallelRuns) are handled by an explicit case in addArgs and so never
+// reach this list at runtime; they are listed for completeness, not effect.
 var PASSTHROUGH_OPTIONS = [
   'key', 'folder', 'help', 'version', 'force', 'only',
   'forcelocal', 'force-local',
@@ -56,8 +62,10 @@ var PASSTHROUGH_OPTIONS = [
 
 // Flags getBinaryArgs() always puts on the argv itself. Accepting them from
 // the options object too would let a caller append a second, conflicting copy
-// — e.g. '--daemon stop' after our '--daemon start'. ('logFile' has its own
-// supported option; only the raw binary alias is reserved.)
+// — e.g. '--daemon stop' after our '--daemon start'. The log file is settable,
+// but only through the wrapper's own 'logfile'/'logFile' case above, which
+// routes it into getBinaryArgs' single '--log-file'; the binary's raw
+// 'log-file' alias is reserved so it cannot add a second one.
 var RESERVED_OPTIONS = ['daemon', 'log-file', 'source'];
 
 // Keys consumed by this wrapper and never meant for the binary.
@@ -208,6 +216,15 @@ function Local(){
     for(var key in options){
       var value = options[key];
 
+      // Runs for EVERY key, including the ones with an explicit case below.
+      // A value is only ever safe as a value: the binary's parser will not
+      // consume one that begins with '-', it reads it as another flag — and it
+      // accepts the '--flag=value' form, so a value like '--log-file=/tmp/x'
+      // smuggles a complete flag in through an otherwise legitimate option.
+      var valueError = this.rejectFlagLikeValue(key, value);
+      if(valueError)
+        return valueError;
+
       switch(key){
       case 'key':
         if(value)
@@ -313,10 +330,24 @@ function Local(){
     }
   };
 
+  // Returns a LocalError if any part of the value would be read as a flag
+  // rather than as this option's value. List-typed options (--include-hosts,
+  // --exclude-hosts) take an array, so every element is checked.
+  this.rejectFlagLikeValue = function(key, value){
+    var values = Array.isArray(value) ? value : [value];
+    for(var i = 0; i < values.length; i++){
+      if(values[i] === undefined || values[i] === null)
+        continue;
+      if(values[i].toString().charAt(0) === '-')
+        return new LocalError('Invalid value for option \'' + key + '\': values starting with \'-\' are not allowed');
+    }
+  };
+
   // Forwards one caller-supplied option to the daemon argv, or returns a
   // LocalError describing why it was refused. Only documented modifiers get
   // through: an unknown key used to be prefixed with '--' and pushed blindly,
   // which let any caller inject arbitrary flags into the native binary.
+  // The value has already been checked by rejectFlagLikeValue in addArgs.
   this.addUserArg = function(key, value){
     if(INTERNAL_OPTIONS.indexOf(key) !== -1)
       return;
@@ -327,20 +358,24 @@ function Local(){
     if(PASSTHROUGH_OPTIONS.indexOf(key) === -1)
       return new LocalError('Unknown option \'' + key + '\'. Only documented BrowserStack Local modifiers are forwarded to the binary, see https://www.browserstack.com/local-testing#modifiers');
 
-    var stringValue = value === undefined || value === null ? '' : value.toString();
+    // Match the explicit cases above, which all guard with `if(value)`.
+    if(value === undefined || value === null)
+      return;
 
-    if(stringValue.toLowerCase() == 'true'){
+    if(value.toString().toLowerCase() == 'true'){
       this.userArgs.push('--' + key);
       return;
     }
 
-    // The binary's argv parser will not consume a value that begins with '-';
-    // it reads it as another flag instead. Refuse rather than smuggle one in.
-    if(stringValue.charAt(0) === '-')
-      return new LocalError('Invalid value for option \'' + key + '\': values starting with \'-\' are not allowed');
-
+    // argv elements must be strings — execFile/spawnSync reject anything else.
     this.userArgs.push('--' + key);
-    this.userArgs.push(value);
+    if(Array.isArray(value)){
+      for(var i = 0; i < value.length; i++){
+        this.userArgs.push(value[i].toString());
+      }
+    } else {
+      this.userArgs.push(value.toString());
+    }
   };
 
   this.getBinaryPath = function(callback, bsHost){

--- a/test/local.js
+++ b/test/local.js
@@ -124,11 +124,11 @@ describe('Local', function () {
     });
   });
 
-  // LOC-6805 / LOC-6783 (F-007, CWE-88): addArgs used to prefix ANY unknown
-  // option key with '--' and push it onto the daemon argv, letting a caller
-  // — or upstream code merging untrusted input into `options` — inject
-  // arbitrary flags into the native binary. Only documented BrowserStackLocal
-  // modifiers may be forwarded now.
+  // Argument injection (CWE-88): addArgs used to prefix ANY unknown option key
+  // with '--' and push it onto the daemon argv, letting a caller — or upstream
+  // code merging untrusted input into `options` — inject arbitrary flags into
+  // the native binary. Only documented BrowserStackLocal modifiers may be
+  // forwarded now, and no value may pose as a flag.
 
   it('should reject unknown boolean args', function (done) {
     bsLocal.start({ 'key': process.env.BROWSERSTACK_ACCESS_KEY, onlyCommand: true, 'boolArg1': true, 'boolArg2': true }, function(error){
@@ -178,6 +178,62 @@ describe('Local', function () {
       expect(error).to.be.an(Error);
       expect(error.toString()).to.contain('values starting with \'-\' are not allowed');
       expect(bsLocal.getBinaryArgs().indexOf('--pac-file')).to.equal(-1);
+      done();
+    });
+  });
+
+  // The value check must cover keys that have an explicit case too, not just
+  // the ones reaching the allowlist. bs-minimist accepts '--flag=value', so a
+  // smuggled flag carries its own value and needs no following argv slot.
+  it('should reject a flag-like value on an explicitly handled option', function (done) {
+    bsLocal.start({ 'key': process.env.BROWSERSTACK_ACCESS_KEY, onlyCommand: true, 'localIdentifier': '--log-file=/tmp/attacker-owned' }, function(error){
+      expect(error).to.be.an(Error);
+      expect(error.toString()).to.contain('values starting with \'-\' are not allowed');
+      const args = bsLocal.getBinaryArgs();
+      expect(args.indexOf('--log-file=/tmp/attacker-owned')).to.equal(-1);
+      expect(args.indexOf('--local-identifier')).to.equal(-1);
+      done();
+    });
+  });
+
+  it('should reject a daemon-lifecycle smuggle through an explicitly handled option', function (done) {
+    bsLocal.start({ 'key': process.env.BROWSERSTACK_ACCESS_KEY, onlyCommand: true, 'only': '--daemon=stop' }, function(error){
+      expect(error).to.be.an(Error);
+      expect(bsLocal.getBinaryArgs().indexOf('--daemon=stop')).to.equal(-1);
+      done();
+    });
+  });
+
+  it('should reject a flag-like element inside a list-valued option', function (done) {
+    bsLocal.start({ 'key': process.env.BROWSERSTACK_ACCESS_KEY, onlyCommand: true, 'include-hosts': ['localhost', '--config-file=/tmp/attacker.yml'] }, function(error){
+      expect(error).to.be.an(Error);
+      expect(bsLocal.getBinaryArgs().indexOf('--config-file=/tmp/attacker.yml')).to.equal(-1);
+      done();
+    });
+  });
+
+  it('should forward a list-valued option as separate argv elements', function (done) {
+    bsLocal.start({ 'key': process.env.BROWSERSTACK_ACCESS_KEY, onlyCommand: true, 'include-hosts': ['localhost', '127.0.0.1'] }, function(error){
+      expect(error).to.equal(undefined);
+      const args = bsLocal.getBinaryArgs();
+      expect(args.indexOf('--include-hosts')).to.not.equal(-1);
+      expect(args.indexOf('localhost')).to.not.equal(-1);
+      expect(args.indexOf('127.0.0.1')).to.not.equal(-1);
+      done();
+    });
+  });
+
+  it('should skip a null or undefined passthrough value instead of pushing it raw', function (done) {
+    // execFile/spawnSync reject a non-string argv element, so a raw null here
+    // used to throw ERR_INVALID_ARG_TYPE out of start() instead of erroring.
+    bsLocal.start({ 'key': process.env.BROWSERSTACK_ACCESS_KEY, onlyCommand: true, 'region': null, 'connect-timeout': 30 }, function(error){
+      expect(error).to.equal(undefined);
+      const args = bsLocal.getBinaryArgs();
+      expect(args.indexOf('--region')).to.equal(-1);
+      expect(args.indexOf(null)).to.equal(-1);
+      // numbers are coerced, so every argv element is a string
+      expect(args.indexOf('30')).to.not.equal(-1);
+      expect(args.every(function(a){ return typeof a === 'string'; })).to.equal(true);
       done();
     });
   });

--- a/test/local.js
+++ b/test/local.js
@@ -124,20 +124,80 @@ describe('Local', function () {
     });
   });
 
-  it('should enable custom boolean args', function (done) {
-    bsLocal.start({ 'key': process.env.BROWSERSTACK_ACCESS_KEY, onlyCommand: true, 'boolArg1': true, 'boolArg2': true }, function(){
-      expect(bsLocal.getBinaryArgs().indexOf('--boolArg1')).to.not.equal(-1);
-      expect(bsLocal.getBinaryArgs().indexOf('--boolArg2')).to.not.equal(-1);
+  // LOC-6805 / LOC-6783 (F-007, CWE-88): addArgs used to prefix ANY unknown
+  // option key with '--' and push it onto the daemon argv, letting a caller
+  // — or upstream code merging untrusted input into `options` — inject
+  // arbitrary flags into the native binary. Only documented BrowserStackLocal
+  // modifiers may be forwarded now.
+
+  it('should reject unknown boolean args', function (done) {
+    bsLocal.start({ 'key': process.env.BROWSERSTACK_ACCESS_KEY, onlyCommand: true, 'boolArg1': true, 'boolArg2': true }, function(error){
+      expect(error).to.be.an(Error);
+      expect(error.toString()).to.contain('Unknown option \'boolArg1\'');
+      expect(bsLocal.getBinaryArgs().indexOf('--boolArg1')).to.equal(-1);
+      expect(bsLocal.getBinaryArgs().indexOf('--boolArg2')).to.equal(-1);
       done();
     });
   });
 
-  it('should enable custom keyval args', function (done) {
-    bsLocal.start({ 'key': process.env.BROWSERSTACK_ACCESS_KEY, onlyCommand: true, 'customKey1': 'custom value1', 'customKey2': 'custom value2' }, function(){
-      expect(bsLocal.getBinaryArgs().indexOf('--customKey1')).to.not.equal(-1);
-      expect(bsLocal.getBinaryArgs().indexOf('custom value1')).to.not.equal(-1);
-      expect(bsLocal.getBinaryArgs().indexOf('--customKey2')).to.not.equal(-1);
-      expect(bsLocal.getBinaryArgs().indexOf('custom value2')).to.not.equal(-1);
+  it('should reject unknown keyval args', function (done) {
+    bsLocal.start({ 'key': process.env.BROWSERSTACK_ACCESS_KEY, onlyCommand: true, 'customKey1': 'custom value1', 'customKey2': 'custom value2' }, function(error){
+      expect(error).to.be.an(Error);
+      expect(error.toString()).to.contain('Unknown option \'customKey1\'');
+      expect(bsLocal.getBinaryArgs().indexOf('--customKey1')).to.equal(-1);
+      expect(bsLocal.getBinaryArgs().indexOf('custom value1')).to.equal(-1);
+      done();
+    });
+  });
+
+  it('should reject the reported flag-injection payload', function (done) {
+    bsLocal.start({ 'key': process.env.BROWSERSTACK_ACCESS_KEY, onlyCommand: true, 'config': '/tmp/attacker.conf', 'daemon': 'stop' }, function(error){
+      expect(error).to.be.an(Error);
+      const args = bsLocal.getBinaryArgs();
+      expect(args.indexOf('--config')).to.equal(-1);
+      expect(args.indexOf('/tmp/attacker.conf')).to.equal(-1);
+      // the wrapper's own '--daemon start' must be the only daemon flag
+      expect(args.indexOf('stop')).to.equal(-1);
+      done();
+    });
+  });
+
+  it('should reject options the wrapper sets itself', function (done) {
+    bsLocal.start({ 'key': process.env.BROWSERSTACK_ACCESS_KEY, onlyCommand: true, 'log-file': '/tmp/attacker-owned' }, function(error){
+      expect(error).to.be.an(Error);
+      expect(error.toString()).to.contain('set by browserstack-local itself');
+      expect(bsLocal.getBinaryArgs().indexOf('/tmp/attacker-owned')).to.equal(-1);
+      done();
+    });
+  });
+
+  it('should reject a value that would be parsed as another flag', function (done) {
+    // bs-minimist does not consume a value beginning with '-'; it reads it as
+    // a separate flag, so a legitimate key can still smuggle one in.
+    bsLocal.start({ 'key': process.env.BROWSERSTACK_ACCESS_KEY, onlyCommand: true, 'region': '--pac-file' }, function(error){
+      expect(error).to.be.an(Error);
+      expect(error.toString()).to.contain('values starting with \'-\' are not allowed');
+      expect(bsLocal.getBinaryArgs().indexOf('--pac-file')).to.equal(-1);
+      done();
+    });
+  });
+
+  it('should not forward wrapper-internal keys to the binary', function (done) {
+    bsLocal.start({ 'key': process.env.BROWSERSTACK_ACCESS_KEY, onlyCommand: true }, function(error){
+      expect(error).to.equal(undefined);
+      expect(bsLocal.getBinaryArgs().indexOf('--onlyCommand')).to.equal(-1);
+      done();
+    });
+  });
+
+  it('should still forward documented modifiers that have no explicit case', function (done) {
+    bsLocal.start({ 'key': process.env.BROWSERSTACK_ACCESS_KEY, onlyCommand: true, 'localProxyHost': '127.0.0.1', 'pac-file': '/tmp/proxy.pac' }, function(error){
+      expect(error).to.equal(undefined);
+      const args = bsLocal.getBinaryArgs();
+      expect(args.indexOf('--localProxyHost')).to.not.equal(-1);
+      expect(args.indexOf('127.0.0.1')).to.not.equal(-1);
+      expect(args.indexOf('--pac-file')).to.not.equal(-1);
+      expect(args.indexOf('/tmp/proxy.pac')).to.not.equal(-1);
       done();
     });
   });


### PR DESCRIPTION
## Problem

`addArgs()` prefixed **any** unrecognised key of the caller-supplied `options` object with `--` and pushed it, with its value, onto the `BrowserStackLocal` daemon argv:

```js
default:
  this.userArgs.push('--' + key);
  this.userArgs.push(value);
```

`getBinaryArgs()` appends `userArgs` verbatim into the `spawnSync` / `execFile` argv, so any caller — or upstream code that merges untrusted input into `options` — could shape the native binary's argv. Argument injection, CWE-88.

## Fix

Two rules, both enforced before anything reaches the argv:

1. **Keys** — only documented BrowserStackLocal modifiers are forwarded. `PASSTHROUGH_OPTIONS` mirrors the binary's own CLI definition (`COMMAND_CONFIGURATION` in browserStackTunnel) — long names and aliases — so anything now refused is something the binary would not have acted on anyway. `daemon`, `log-file` and `source` are reserved because `getBinaryArgs()` sets them itself and a caller must not be able to append a conflicting second copy.
2. **Values** — a value may never pose as a flag. The binary's parser will not consume a value beginning with `-`; it reads it as another flag. The check runs in `addArgs` above the `switch`, so it covers every key, and each element of a list-valued option is checked.

`addArgs` returns a `LocalError`, delivered through the existing paths: `callback(err)` for `start()`, returned for `startSync()`.

## Compatibility

Documented modifiers keep working — verified for `localProxyHost`/`Port`/`User`/`Pass`, `pac-file`, `local-proxy-port`, `custom-repeater`, `bs-host`, `include-hosts`, and the explicitly-cased options.

Behaviour change worth a reviewer's nod: **an unknown option key is now an error** rather than a silent no-op forward, and so is a value starting with `-`. The latter is not a regression — such values are already mis-parsed today, the option silently becoming `true`.

Edge case called out: a value starting with `-` is refused even where it might be legitimate (e.g. an `ntlm-password` beginning with `-`). That case does not work today either.

## Test plan

- [x] `npm test` — eslint clean; **12 argument-handling tests pass**; all pre-existing tests before the (pre-existing) `should stop local` abort still pass. That abort reproduces on untouched `master`.
- [x] Two tests that *asserted the vulnerable behaviour* replaced with rejection tests.
- [x] Standalone repro covering the reported payload, the reserved keys, value smuggling through **explicitly-cased** keys (`--flag=value` form), list elements, and positive checks on documented modifiers: **29 failures → 0**.
- [x] `mocha --grep "Start sync"` in isolation — 2 passing, 1 pending.
- [x] Real tunnel started **through the binding**, Automate session over it, graceful `.stop()`.
- [ ] Fetching a page on the tester's machine inside the remote browser returned "Page not found". A control run of the same harness against pristine `master` fails **identically**, and verbose tunnel logs show the request never reaches the binary — an environment-side tunnel attach issue, not argv construction.

## Review round 1

The value check previously lived in the passthrough helper, so the ~21 options with an explicit `switch` case bypassed it and could still smuggle a flag as their value. Now hoisted above the `switch`. Also from review: null/undefined values are skipped and argv elements are coerced to strings; the shadowed entries in the allowlist are documented as listed-for-completeness.

Note for the merger: please **squash-merge**. The first commit's message body still carries internal tracker/finding ids; squashing lets you set a single clean message. No such id ships in the tree.
