### PR TITLE
Keep the access key out of child argv; honour useCaCertificate without a proxy

### DIFF
--- a/.github/workflows/Semgrep.yml
+++ b/.github/workflows/Semgrep.yml
@@ -27,7 +27,10 @@ jobs:
 
     container:
       # A Docker image with Semgrep installed. Do not change this.
-      image: returntocorp/semgrep:1.166.0
+      # Pinned to an immutable digest so a mutated tag cannot redirect CI to a
+      # different image. Refresh with:
+      #   docker manifest inspect returntocorp/semgrep:<tag>
+      image: returntocorp/semgrep:1.166.0@sha256:c180f0c93a17b420c0af5006214a29d3c747c5459c732b740191adf657dd0068
     # Skip any PR created by dependabot to avoid permission issues:
     if: (github.actor != 'dependabot[bot]')
 

--- a/lib/LocalBinary.js
+++ b/lib/LocalBinary.js
@@ -34,7 +34,9 @@ function LocalBinary(){
 
     let cmd, opts;
     cmd = 'node';
-    opts = [path.join(__dirname, 'fetchDownloadSourceUrl.js'), this.key, this.bsHost];
+    /* The auth token is handed to the child through its environment, not argv —
+       argv is readable by any local user via `ps` / /proc/<pid>/cmdline. */
+    opts = [path.join(__dirname, 'fetchDownloadSourceUrl.js'), this.bsHost];
 
     if (retries == 4 || (process.env.BINARY_DOWNLOAD_FALLBACK_ENABLED == 'true' && this.parentRetries == 4)) {
       opts.push(true, this.downloadErrorMessage || process.env.BINARY_DOWNLOAD_ERROR_MESSAGE);
@@ -53,6 +55,9 @@ function LocalBinary(){
 
     const userAgent = [packageName, version].join('/');
     const env = Object.assign({ 'USER_AGENT': userAgent }, process.env);
+    if (this.key) {
+      env.BROWSERSTACK_LOCAL_AUTH_TOKEN = this.key;
+    }
     const obj = childProcess.spawnSync(cmd, opts, { env: env });
     if(obj.stdout.length > 0) {
       this.sourceURL = obj.stdout.toString().replace(/\n+$/, '');
@@ -135,10 +140,11 @@ function LocalBinary(){
     var that = this;
     if(retries > 0) {
       console.log('Retrying Download. Retries left', retries);
-      fs.stat(binaryPath, function(err) {
-        if(err == null) {
-          fs.unlinkSync(binaryPath);
-        }
+      /* Single unlink instead of stat-then-unlinkSync: the gap between the two
+         let a concurrent writer swap the file, and a failing unlinkSync threw
+         out of the stat callback where it could not be caught. A missing file
+         is the expected case here, so any error is ignored. */
+      fs.unlink(binaryPath, function() {
         if(!callback) {
           return that.downloadSync(conf, destParentDir, retries - 1);
         }
@@ -310,18 +316,38 @@ function LocalBinary(){
   this.getAvailableDirs = function(){
     for(var i=0; i < this.orderedPaths.length; i++){
       var path = this.orderedPaths[i];
-      if(this.makePath(path))
+      // the last entry lives under the shared temp dir — it must be ours alone
+      var requirePrivate = (i === this.orderedPaths.length - 1);
+      if(this.makePath(path, requirePrivate))
         return path;
     }
     throw new LocalError('Error trying to download BrowserStack Local binary');
   };
 
-  this.makePath = function(path){
+  this.makePath = function(path, requirePrivate){
     try {
       if(!this.checkPath(path)){
-        fs.mkdirSync(path);
+        fs.mkdirSync(path, { mode: 0o700 });
       }
-      return true;
+      return requirePrivate ? this.isUserPrivateDir(path) : true;
+    } catch(e){
+      return false;
+    }
+  };
+
+  /* Only applied to the shared-temp fallback. The binary is written there and
+     then executed, so that directory must not be writable by anyone but us —
+     otherwise another local user can swap the binary between the download and
+     the exec, or pre-create the path as a symlink. Windows has no POSIX mode
+     bits; there this is a no-op. */
+  this.isUserPrivateDir = function(dirPath){
+    if(process.platform === 'win32' || typeof process.getuid !== 'function') return true;
+    try {
+      var stats = fs.lstatSync(dirPath);
+      if(!stats.isDirectory()) return false;
+      if(stats.uid !== process.getuid()) return false;
+      // reject group- or world-writable
+      return (stats.mode & 0o022) === 0;
     } catch(e){
       return false;
     }
@@ -349,10 +375,18 @@ function LocalBinary(){
     return home || null;
   };
 
+  /* The last entry is a per-user subdirectory of the temp dir rather than the
+     temp dir itself: os.tmpdir() is /tmp on Linux, which is world-writable, and
+     the binary name below it is fixed and predictable. */
+  this.tmpDirPath = function(){
+    var suffix = (typeof process.getuid === 'function') ? String(process.getuid()) : 'user';
+    return path.join(os.tmpdir(), 'browserstack-local-' + suffix);
+  };
+
   this.orderedPaths = [
     path.join(this.homedir(), '.browserstack'),
     process.cwd(),
-    os.tmpdir()
+    this.tmpDirPath()
   ];
 }
 

--- a/lib/download.js
+++ b/lib/download.js
@@ -2,24 +2,33 @@ const https = require('https'),
   fs = require('fs'),
   HttpsProxyAgent = require('https-proxy-agent'),
   url = require('url'),
-  zlib = require('zlib');
+  zlib = require('zlib'),
+  { isUndefined } = require('./util');
 
 const binaryPath = process.argv[2], httpPath = process.argv[3], proxyHost = process.argv[4], proxyPort = process.argv[5], useCaCertificate = process.argv[6];
 
 var fileStream = fs.createWriteStream(binaryPath);
 
 var options = url.parse(httpPath);
-if(proxyHost && proxyPort) {
+/* isUndefined, not plain truthiness: the parent passes literal `undefined`
+   placeholders for the proxy slots when only a CA is configured, and those
+   arrive here as the *string* "undefined" — which is truthy, and previously
+   built a proxy agent pointing at the host "undefined". */
+if(!isUndefined(proxyHost) && !isUndefined(proxyPort)) {
   options.agent = new HttpsProxyAgent({
     host: proxyHost,
     port: proxyPort
   });
-  if (useCaCertificate) {
-    try {
-      options.ca = fs.readFileSync(useCaCertificate);
-    } catch(err) {
-      console.log('failed to read cert file', err);
-    }
+}
+
+/* Applied regardless of whether a proxy is configured: this is the caller's TLS
+   trust anchor, and silently falling back to the system store when no proxy is
+   set ignored what they asked for. Mirrors LocalBinary.js's async download path. */
+if (!isUndefined(useCaCertificate)) {
+  try {
+    options.ca = fs.readFileSync(useCaCertificate);
+  } catch(err) {
+    console.log('failed to read cert file', err);
   }
 }
 

--- a/lib/fetchDownloadSourceUrl.js
+++ b/lib/fetchDownloadSourceUrl.js
@@ -3,7 +3,10 @@ const https = require('https'),
   HttpsProxyAgent = require('https-proxy-agent'),
   { isUndefined } = require('./util');
 
-const authToken = process.argv[2], bsHost = process.argv[3], proxyHost = process.argv[6], proxyPort = process.argv[7], useCaCertificate = process.argv[8], downloadFallback = process.argv[4], downloadErrorMessage = process.argv[5];
+/* The auth token is read from the environment, never from argv: argv is world-readable
+   via `ps` / /proc/<pid>/cmdline, whereas /proc/<pid>/environ is restricted to the
+   owning user. Keep it out of this argument list. */
+const authToken = process.env.BROWSERSTACK_LOCAL_AUTH_TOKEN, bsHost = process.argv[2], proxyHost = process.argv[5], proxyPort = process.argv[6], useCaCertificate = process.argv[7], downloadFallback = process.argv[3], downloadErrorMessage = process.argv[4];
 
 let body = '', data = {'auth_token': authToken};
 const options = {


### PR DESCRIPTION
Five fixes in the binary-download path, found by a security review of this repo.
Each is small and independent; they are batched because they touch the same
three files.

## 1. Access key no longer passed in child argv (CWE-214)

`LocalBinary.getSourceUrlSync` spawned `lib/fetchDownloadSourceUrl.js` with the
access key as a positional argument, so the key was visible to **any local user**
via `ps aux` or `/proc/<pid>/cmdline` for the duration of the spawn — a real
concern on shared CI runners and multi-tenant hosts.

The key now travels in the child's environment instead (`/proc/<pid>/environ` is
readable only by the owning user). The remaining argv slots shift down by one and
`fetchDownloadSourceUrl.js` was updated to match.

## 2. `useCaCertificate` is honoured when no proxy is configured (CWE-295)

`lib/download.js` only loaded the CA bundle **inside** the
`if (proxyHost && proxyPort)` branch, so a caller-supplied TLS trust anchor was
silently ignored whenever no proxy was set.

While fixing that I found the same lines were also **functionally broken**:
`LocalBinary.downloadSync` pushes literal `undefined` placeholders into the proxy
slots when only a CA is configured, and those reach the child as the *string*
`"undefined"` — which is truthy. The sync download therefore built an
`HttpsProxyAgent` for host `"undefined"` and failed outright.

Verified against unmodified `master`:

```
# master:  useCaCertificate set, no proxy
Got Error in binary downloading request Error: getaddrinfo ENOTFOUND undefined
--- bytes downloaded: 0 ---

# this branch: same invocation
Done
--- bytes downloaded: 40605816 ---
```

The proxy slots are now compared with the existing `isUndefined` helper (which
`lib/fetchDownloadSourceUrl.js` already uses for exactly this reason), and the CA
block moved outside the proxy branch. Confirmed the CA is genuinely the trust
anchor: with an unrelated self-signed CA the download now fails with
`unable to get local issuer certificate` instead of silently succeeding on the
system store.

## 3. Retry unlink is a single ENOENT-tolerant call (CWE-362)

`retryBinaryDownload` did an async `fs.stat` and then a synchronous
`fs.unlinkSync` inside its callback. Collapsed into one `fs.unlink` that ignores
the error: it removes the window between check and delete, and also removes the
uncatchable throw that a failing `unlinkSync` raised from inside the stat
callback.

## 4. Temp fallback is a user-private directory (CWE-377)

`getAvailableDirs` fell back to `os.tmpdir()` itself — `/tmp` on Linux, which is
world-writable — under the fixed, predictable name `BrowserStackLocal`. Since
that file is chmod'd 0755 and then executed, another local user could pre-create
the path or swap the file.

The fallback is now a per-uid subdirectory created `0700`, and it is rejected
unless it is a real directory, owned by the current uid, and not group- or
world-writable. **Only the temp fallback is checked** — `$HOME/.browserstack` and
`process.cwd()` keep their existing behaviour, so a group-writable working
directory (common on shared CI) still works as before.

Note: on the temp-fallback path only, an existing `/tmp/BrowserStackLocal` is no
longer reused, so the binary is re-downloaded once.

## 5. Semgrep CI image pinned to a digest (CWE-829)

`.github/workflows/Semgrep.yml` referenced a mutable tag. Pinned to
`@sha256:c180f0c9…` so a re-pointed tag cannot redirect CI to a different image.
This matches the existing practice in the same file of pinning actions to commit
SHAs. Refresh with `docker manifest inspect returntocorp/semgrep:<tag>`.

## Testing

- `eslint lib/* index.js` — clean.
- `mocha --grep LocalBinary` — `Retries` (the `retryBinaryDownload` path changed
  here) and `Binary filename` pass. The `Download` block errors with
  `Invalid auth token` **on `master` too** — those specs construct `LocalBinary`
  directly and never set `binary.key`, so this is pre-existing and unrelated.
- 15 targeted checks covering all five fixes — argv contains no key while the
  child still resolves it from env, argv positions still map correctly after the
  shift, CA applied/enforced without a proxy, retry proceeds on ENOENT,
  world-writable and symlinked temp dirs rejected, non-temp paths unaffected.
- Live: endpoint resolved and the 36 MB binary downloaded through the patched
  sync path with the token supplied only via env.
- Live: a tunnel started **through this binding** carried a real BrowserStack
  Automate session to a local page (`bs-local.com`), then stopped cleanly with no
  dangling process.

No regression test was added for the digest pin (config-only).

## Not addressed here

The daemon is still launched with `--key <value>` in its argv, so the key remains
visible in the process list for the tunnel's lifetime. Closing that needs a
`--key-file`/env option in the `BrowserStackLocal` binary itself and a matching
change across all six language bindings — tracked separately.