### PR TITLE
LOC-7291: download darwin-arm64 binary on Apple Silicon

### DIFF
--- a/lib/LocalBinary.js
+++ b/lib/LocalBinary.js
@@ -93,7 +93,11 @@ function LocalBinary(){
 
   this.getBinaryFilename = function() {
     if(this.hostOS.match(/darwin|mac os/i)){
-      return 'BrowserStackLocal-darwin-x64';
+      if(this.isArm64) {
+        return 'BrowserStackLocal-darwin-arm64';
+      } else {
+        return 'BrowserStackLocal-darwin-x64';
+      }
     } else if(this.hostOS.match(/mswin|msys|mingw|cygwin|bccwin|wince|emc|win32/i)) {
       this.windows = true;
       return 'BrowserStackLocal.exe';

--- a/test/local.js
+++ b/test/local.js
@@ -393,7 +393,16 @@ describe('LocalBinary', function () {
     it('should return darwin binary filename', function() {
       ['darwin', 'mac os'].forEach(function(os) {
         localBinary.hostOS = os;
+        localBinary.isArm64 = false;
         expect(localBinary.getBinaryFilename()).to.equal('BrowserStackLocal-darwin-x64');
+      });
+    });
+
+    it('should return darwin arm64 binary filename', function() {
+      ['darwin', 'mac os'].forEach(function(os) {
+        localBinary.hostOS = os;
+        localBinary.isArm64 = true;
+        expect(localBinary.getBinaryFilename()).to.equal('BrowserStackLocal-darwin-arm64');
       });
     });
 


### PR DESCRIPTION
## What

On macOS, the binding now downloads `BrowserStackLocal-darwin-arm64` when the runtime reports arm64; x64 runtimes (including x64-under-Rosetta) keep `BrowserStackLocal-darwin-x64`, preserving current behavior.

Detection: process.arch (existing isArm64 flag).

## Why

The Local binary now ships a native Apple Silicon build (browserstack/browserStackTunnel#980). macOS 27 (fall 2026) removes Rosetta 2, so arm64 Macs need the native binary.

## Testing

Unit test updated + new arm64 case; behavior exercised directly with node for both arches.

## ⚠ Release ordering

Do not release this before:
- browserstack/browserStackTunnel#980 is merged and a master build has published `binaries/master/BrowserStackLocal-darwin-arm64.zip` (public ACL line is already in the Jenkins job) — otherwise arm64 Macs get download failures.

## Related Jira

LOC-7291 / epic LOC-7287 (LOC-7285 = binary PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)