### PR TITLE
LOC-7325: stop uncatchable TypeError on empty binary output in Local.start

### DIFF
--- a/lib/Local.js
+++ b/lib/Local.js
@@ -57,7 +57,7 @@ function Local(){
       else
         return new LocalError('No output received');
       if(data['state'] != 'connected'){
-        return new LocalError(data['message']['message']);
+        return new LocalError(that.getErrorMessage(data));
       } else {
         that.pid = data['pid'];
         that.isProcessRunning = true;
@@ -112,19 +112,25 @@ function Local(){
             return;
           } else {
             callback(new LocalError(error.toString()));
+            return;
           }
         }
 
         var data = {};
-        if(stdout)
-          data = JSON.parse(stdout);
-        else if(stderr)
-          data = JSON.parse(stderr);
-        else
+        var output = stdout || stderr;
+        if(!output) {
           callback(new LocalError('No output received'));
+          return;
+        }
+        try {
+          data = JSON.parse(output);
+        } catch(parseError) {
+          callback(new LocalError('Invalid output received: ' + parseError.message, output));
+          return;
+        }
 
         if(data['state'] != 'connected'){
-          callback(new LocalError(data['message']['message']));
+          callback(new LocalError(that.getErrorMessage(data)));
         } else {
           that.pid = data['pid'];
           that.isProcessRunning = true;
@@ -132,6 +138,17 @@ function Local(){
         }
       });
     }, options['bs-host']);
+  };
+
+  // The binary reports failures as {"state": "...", "message": {"message": "..."}},
+  // but not every non-connected payload carries a message key. Dereferencing it
+  // blindly throws, and inside the execFile callback that throw is an
+  // uncaughtException the caller cannot catch. See LOC-7325.
+  this.getErrorMessage = function(data){
+    var message = data && data['message'];
+    if(message && typeof message === 'object')
+      message = message['message'];
+    return message || 'Failed to start BrowserStack Local';
   };
 
   this.isRunning = function(){

--- a/test/local_start_output_handling.js
+++ b/test/local_start_output_handling.js
@@ -1,0 +1,104 @@
+var expect = require('expect.js'),
+    fs = require('fs'),
+    os = require('os'),
+    path = require('path'),
+    browserstack = require('../index');
+
+// Regression tests for LOC-7325.
+//
+// `Local.start` handles the binary's output inside an `execFile` callback. A
+// throw there is raised by node's internal exithandler, so no try/catch around
+// `start()` can intercept it — it surfaces as an uncaughtException and the
+// blast radius is set by the host process's exception policy. These tests drive
+// `start()` with stub binaries that reproduce each output shape and assert the
+// callback fires exactly once with an error, and that nothing throws.
+//
+// Stubs are shell scripts, so these are skipped on Windows.
+describe('Local.start output handling', function () {
+  var stubDir, bsLocal;
+
+  function stub(name, body) {
+    var stubPath = path.join(stubDir, name);
+    fs.writeFileSync(stubPath, '#!/bin/sh\n' + body + '\n', { mode: 0o755 });
+    return stubPath;
+  }
+
+  // Drives start() with the given stub and collects every callback invocation
+  // plus any uncaughtException raised out of the execFile callback.
+  function run(stubPath, done) {
+    var calls = [], uncaught = [];
+    var existing = process.listeners('uncaughtException');
+    process.removeAllListeners('uncaughtException');
+    process.on('uncaughtException', function (err) { uncaught.push(err); });
+
+    bsLocal.binaryPath = stubPath;
+    bsLocal.start({ key: 'dummy-key', localIdentifier: 'loc-7325' }, function (error) {
+      calls.push(error);
+    });
+
+    // Settle past the execFile callback before asserting, so a second
+    // (throwing) invocation would have happened by now if it were going to.
+    setTimeout(function () {
+      process.removeAllListeners('uncaughtException');
+      existing.forEach(function (listener) { process.on('uncaughtException', listener); });
+      done(calls, uncaught);
+    }, 1000);
+  }
+
+  before(function () {
+    stubDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bs-local-7325-'));
+  });
+
+  beforeEach(function () {
+    bsLocal = new browserstack.Local();
+    // Keep the stubs from clobbering ./local.log in the repo root.
+    bsLocal.logfile = path.join(stubDir, 'local.log');
+  });
+
+  if (os.platform().match(/win32/i)) {
+    it.skip('skipped on Windows (stub binaries are shell scripts)');
+    return;
+  }
+
+  it('reports an error exactly once when the binary exits with no output', function (done) {
+    this.timeout(10000);
+    run(stub('empty-output.sh', 'exit 0'), function (calls, uncaught) {
+      expect(uncaught).to.eql([]);
+      expect(calls.length).to.equal(1);
+      expect(calls[0]).to.be.an('object');
+      expect(calls[0].message).to.equal('No output received');
+      done();
+    });
+  });
+
+  it('reports an error exactly once when the binary emits non-JSON output', function (done) {
+    this.timeout(10000);
+    run(stub('garbage-output.sh', 'echo "segmentation fault"; exit 0'), function (calls, uncaught) {
+      expect(uncaught).to.eql([]);
+      expect(calls.length).to.equal(1);
+      expect(calls[0].message).to.match(/^Invalid output received: /);
+      expect(calls[0].extra).to.match(/segmentation fault/);
+      done();
+    });
+  });
+
+  it('reports a fallback message when a non-connected payload has no message key', function (done) {
+    this.timeout(10000);
+    run(stub('no-message-key.sh', 'echo \'{"state":"disconnected"}\'; exit 0'), function (calls, uncaught) {
+      expect(uncaught).to.eql([]);
+      expect(calls.length).to.equal(1);
+      expect(calls[0].message).to.equal('Failed to start BrowserStack Local');
+      done();
+    });
+  });
+
+  it('surfaces the binary message when a non-connected payload carries one', function (done) {
+    this.timeout(10000);
+    run(stub('with-message.sh', 'echo \'{"state":"disconnected","message":{"message":"Invalid key"}}\'; exit 0'), function (calls, uncaught) {
+      expect(uncaught).to.eql([]);
+      expect(calls.length).to.equal(1);
+      expect(calls[0].message).to.equal('Invalid key');
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Fixes an uncatchable `TypeError` thrown out of `Local.start()` when the BrowserStackLocal binary exits with no output.

JIRA Story: https://browserstack.atlassian.net/browse/LOC-7325

### The bug

`start()` handles the binary's output inside an `execFile` callback. The empty-output branch called back with `No output received` but did not `return`, so control fell through to the next statement, which dereferences `data['message']['message']` on `data = {}`:

```
TypeError: Cannot read properties of undefined (reading 'message')
    at .../browserstack-local/lib/Local.js:127:50
```

Two things make this worse than a normal error path:

- **The callback fires twice** — once legitimately with `No output received`, then again from the throwing statement.
- **The caller cannot catch it.** The throw happens inside a callback invoked by node's internal `exithandler`, so no `try`/`catch` around `local.start(...)` intercepts it. It surfaces as an `uncaughtException`, which means the blast radius is set by the *host* process's exception policy, not by this package. In the case that surfaced it, a host with a fatal `uncaughtException` handler lost its entire reporting plane because an optional tunnel failed to start.

The trigger is not exotic — any environment where the binary exits without emitting JSON reaches it: wrong or blocked binary path, killed process, permission failure, or a shimmed binary in CI.

### The fix

Three paths reached the same unguarded deref; all three are now closed:

| Path | Before | After |
| --- | --- | --- |
| Empty stdout **and** stderr | callback, then fall through and throw | callback once, then `return` |
| Terminal branch of the `error` handler | callback, then fall through and throw | callback once, then `return` |
| Non-connected payload with no `message` key | throws | falls back to `Failed to start BrowserStack Local` |

Also guarded `JSON.parse`: non-JSON output (a plain-text crash message, for instance) threw a `SyntaxError` from the same uncatchable position. It is now reported through the callback as `Invalid output received: <reason>`, with the raw output attached as the error's `extra` field.

`startSync` shared the unguarded deref and now uses the same helper. Its empty-output branch already returned, so it was never exposed to the fall-through.

Every changed path now invokes the callback **exactly once** and lets the caller handle the failure normally.

### Tests

Added `test/local_start_output_handling.js` — drives `start()` with stub binaries for each output shape and asserts the callback fires exactly once *and* that nothing escapes as an `uncaughtException`. No credentials or network needed.

Verified the tests actually catch the defect by toggling the fix:

- **On `master`:** 3 of the 4 fail, with the ticket's exact `TypeError: Cannot read properties of undefined (reading 'message')`.
- **With this change:** all 4 pass.

Full suite run with real credentials, excluding the `LocalBinary > Download` block (it hangs on `master` and on this branch — its harness never sets `binary.key`, which is a separate pre-existing problem):

- 34 passing, 1 failing, 2 pending

The single failure is `should stop local`, which fails identically on `master` — verified by running that test against `origin/master`'s `lib`. It is unrelated to this change: `stop()` calls back when SIGTERM is sent rather than when the process has exited. `npm run pretest` (eslint over `lib/* index.js`) is clean.

Note: the fix avoids optional chaining because the repo's eslint config sets `env: es6` (ES2015).

### Scope

Code fix only — no version bump or publish here. `1.5.13` is the latest published version and carries the defect, so this needs a release to reach consumers.


---

### Behavior note (changelog)

`startSync` now **returns** a `LocalError('Invalid output received: ...')` when the binary prints unparseable output, instead of throwing after deleting and re-downloading the binary. This matches its existing return-an-error contract for empty-output and non-connected payloads (the known external consumer, browserstack-node-sdk, checks the return value). Raw binary output attached to errors is exposed as `error.extra`, truncated to 1KB.


**Round 3 additions:**
- A connected payload with a pid now counts as **success** even if the foreground process exits non-zero (previously contradictory: error reported while `isRunning()` was true; `startSync` already behaved this way).
- A downloaded binary that runs but prints unparseable output is **evicted without retrying**, so the next `start` re-downloads a fresh copy; binaries passed via `binarypath` are never evicted.
- Terminal download failure (source URL unreachable / retries exhausted) now fails `start()` immediately with the recorded download error instead of hanging or cascading into ~100 retry attempts.
- Deterministic binary failures that exit non-zero with a JSON diagnostic fail fast with that message instead of burning the 9-cycle re-download budget first.

