### PR TITLE
fix: pass proxy credentials to binary download (fixes #164)

### DIFF
--- a/lib/LocalBinary.js
+++ b/lib/LocalBinary.js
@@ -218,10 +218,14 @@ function LocalBinary(){
 
       var options = url.parse(this.httpPath);
       if(conf.proxyHost && conf.proxyPort) {
-        options.agent = new HttpsProxyAgent({
+        var proxyOptions = {
           host: conf.proxyHost,
           port: conf.proxyPort
-        });
+        };
+        if(conf.proxyUser && conf.proxyPass) {
+          proxyOptions.auth = conf.proxyUser + ':' + conf.proxyPass;
+        }
+        options.agent = new HttpsProxyAgent(proxyOptions);
       }
       if (conf.useCaCertificate) {
         try {

--- a/test/local.js
+++ b/test/local.js
@@ -482,6 +482,52 @@ describe('LocalBinary', function () {
       });
     });
 
+    it('should pass proxy authentication to the binary download when proxyUser/proxyPass are set', function () {
+      var https = require('https');
+      var getDownloadPathStub = sinon.stub(binary, 'getDownloadPath', function (conf, retries, cb) {
+        cb(null, 'https://bstack-downloads.example/BrowserStackLocal');
+      });
+      var httpsGetStub = sinon.stub(https, 'get').returns({ on: function () { return this; } });
+
+      try {
+        var conf = {
+          proxyHost: '127.0.0.1',
+          proxyPort: proxyPort,
+          proxyUser: 'user',
+          proxyPass: 'pass'
+        };
+        binary.download(conf, tempDownloadPath, function () {});
+
+        expect(httpsGetStub.calledOnce).to.equal(true);
+        var passedOptions = httpsGetStub.firstCall.args[0];
+        expect(passedOptions.agent).to.be.an('object');
+        expect(passedOptions.agent.proxy.auth).to.equal('user:pass');
+      } finally {
+        httpsGetStub.restore();
+        getDownloadPathStub.restore();
+      }
+    });
+
+    it('should not set proxy authentication when only host/port are provided', function () {
+      var https = require('https');
+      var getDownloadPathStub = sinon.stub(binary, 'getDownloadPath', function (conf, retries, cb) {
+        cb(null, 'https://bstack-downloads.example/BrowserStackLocal');
+      });
+      var httpsGetStub = sinon.stub(https, 'get').returns({ on: function () { return this; } });
+
+      try {
+        var conf = { proxyHost: '127.0.0.1', proxyPort: proxyPort };
+        binary.download(conf, tempDownloadPath, function () {});
+
+        var passedOptions = httpsGetStub.firstCall.args[0];
+        expect(passedOptions.agent).to.be.an('object');
+        expect(passedOptions.agent.proxy.auth).to.equal(undefined);
+      } finally {
+        httpsGetStub.restore();
+        getDownloadPathStub.restore();
+      }
+    });
+
     it('should download binaries in sync', function () {
       this.timeout(MAX_TIMEOUT);
       var conf = {};


### PR DESCRIPTION
## What

`browserstack-local-nodejs` already accepts `proxyUser` / `proxyPass` and forwards them to the `BrowserStackLocal` binary as `--proxy-user` / `--proxy-pass` (see `Local.js`). However, when the library downloads the binary itself, `LocalBinary.download()` builds the `HttpsProxyAgent` with only `host` and `port`:

```js
options.agent = new HttpsProxyAgent({
  host: conf.proxyHost,
  port: conf.proxyPort
});
```

So behind a proxy that requires authentication, the binary download fails with `407 Proxy Authentication Required` even when the user has supplied valid proxy credentials. This is #164.

## Fix

Include the credentials in the proxy agent options when both `proxyUser` and `proxyPass` are provided. `https-proxy-agent@^5` (the version already used here) accepts an `auth: "user:pass"` option, which it sends as the `Proxy-Authorization` header:

```js
var proxyOptions = { host: conf.proxyHost, port: conf.proxyPort };
if (conf.proxyUser && conf.proxyPass) {
  proxyOptions.auth = conf.proxyUser + ':' + conf.proxyPass;
}
options.agent = new HttpsProxyAgent(proxyOptions);
```

The change is scoped to the download path and only adds `auth` when both credentials are present, so existing unauthenticated-proxy and no-proxy behaviour is unchanged.

## Tests

Added two tests to `test/local.js` (they stub `https.get`, so no network is required):

- credentials present -> the proxy agent carries `auth: "user:pass"`.
- only host/port -> no `auth` is set (behaviour unchanged).

Fixes #164
